### PR TITLE
Pv panel longitude

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,18 @@ Power output (in W) of a solar panel with the following characteristics:
 * efficiency of 0.2
 * pointing upwards
 * in NYC
-* on December 25, at 16.15
+* on December 25, at 13.15
 
 ```
 from numpy import array
 from solarpy import solar_panel
 from datetime import datetime
+import pytz
 
 panel = solar_panel(2.1, 0.2, id_name='NYC_xmas')  # surface, efficiency and name
 panel.set_orientation(array([0, 0, -1]))  # upwards
 panel.set_position(40.73, -73.93, 0)  # NYC latitude, longitude, altitude
-panel.set_datetime(datetime(2019, 12, 25, 16, 15))  # Christmas Day!
+panel.set_datetime(datetime(2019, 12, 25, 13, 15, tzinfo=pytz.timezone('US/Eastern')))  # Christmas Day!
 panel.power()
 ```
 

--- a/solarpy/pvpanel.py
+++ b/solarpy/pvpanel.py
@@ -4,7 +4,7 @@
     Photovoltaic panel class
 """
 from .radiation import irradiance_on_plane
-
+from datetime import timezone, timedelta
 
 class solar_panel(object):
     """
@@ -79,4 +79,4 @@ class solar_panel(object):
         Returns the output power of a solar panel
         """
         return irradiance_on_plane(self.vnorm, self.h,
-                                   self.date, self.lat) * self.s * self.eff
+                                   self.date.astimezone(timezone.utc)+timedelta(hours=self.lng/180*12), self.lat) * self.s * self.eff


### PR DESCRIPTION
Currently the longitude property of a panel is not used anywhere., but time of peak irridiance (and therefor peak power) depends on this position.
The calcuation of power has been fixed to account for that variation by converting time to UTC and adding a timedelta according to the longitude.